### PR TITLE
ci: add dependabot for Docker, pip and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 30
+  - package-ecosystem: pip
+    directory: "/app"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 30
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 30


### PR DESCRIPTION
### What
-ci: add dependabot for Docker, pip and github-actions