### PR TITLE
feat: Use `basicConfig()` for logging instead of print

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging as log
+
 from elasticsearch_dsl import Q
 from fastapi import FastAPI
 from fastapi import HTTPException
@@ -15,6 +17,11 @@ from app.utils import response
 
 app = FastAPI()
 connection.get_connection()
+
+log.basicConfig(
+    level=log.INFO, format='%(asctime)s %(message)s',
+    datefmt='%m/%d/%Y %I:%M:%S %p',
+)
 
 
 @app.get('/{barcode}')

--- a/app/import_queue/queue_manager.py
+++ b/app/import_queue/queue_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import logging as log
 
 from app.import_queue.product_client import ProductClient
 from app.import_queue.redis_client import RedisClient
@@ -21,28 +22,21 @@ class QueueManager:
                 continue
             item = self.product_client.get_product(code)
             if not item:
-                print(
-                    'Unable to retrieve product with code {}'.format(
-                        code,
-                    ), flush=True,
-                )
+                log.info(f'Unable to retrieve product with code {code}')
                 continue
             # As the code is unique (set in the save method), this will handle updates as well as new documents
             product = create_product_from_dict(item)
             product.save()
-            print(
-                f'Received Redis update for product: {code} - {product.product_name}', flush=True,
+            log.info(
+                f'Received Redis update for product: {code} - {product.product_name}',
             )
 
             # Now, write a key that can be read for full imports
             self.redis_client.write_processed(product.code)
 
     def stop(self):
-        print(
-            'Stopping redis reader, may take {} seconds'.format(
-                constants.REDIS_READER_TIMEOUT,
-            ),
-            flush=True,
+        log.info(
+            f'Stopping redis reader, may take {constants.REDIS_READER_TIMEOUT} seconds',
         )
         self.stop_received = True
 
@@ -59,7 +53,7 @@ def handle_stop(queues):
 
 def run_queue_safe():
     """Spawn and consume queues until a clean stop happens"""
-    print('Starting redis consumer', flush=True)
+    log.info('Starting redis consumer')
 
     # we need a dict to have a reference
     queues = {'current': None}
@@ -73,7 +67,7 @@ def run_queue_safe():
             queues['current'].consume()
             alive = False
         except Exception as e:
-            print(f'Received {e}, respawning a consumer', flush=True)
+            log.info(f'Received {e}, respawning a consumer')
 
 
 if __name__ == '__main__':

--- a/app/import_queue/redis_client.py
+++ b/app/import_queue/redis_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging as log
 import os
 import time
 
@@ -43,10 +44,10 @@ class RedisClient:
         fetched_codes = set()
         timestamp_processed_values = []
         for key in self.redis.scan_iter('product:*'):
-            print(key)
+            log.info(key)
             components = key.split(':')
             if len(components) != 3:
-                print(f'Invalid key: {key}')
+                log.info(f'Invalid key: {key}')
                 continue
 
             timestamp = components[1]
@@ -60,7 +61,7 @@ class RedisClient:
             fetched_codes.add(code)
             product = product_client.get_product(code)
             if not product:
-                print('Unable to retrieve product: {}'.format(code))
+                log.info(f'Unable to retrieve product: {code}')
                 continue
 
             timestamp_processed_values.append((timestamp, product))


### PR DESCRIPTION
### What
- I have used `basicConfig()` to setup basic logging for the server.

### Fixes bug(s)
- #24 