### PR TITLE
feat: add support for multiple indices

### DIFF
--- a/.env
+++ b/.env
@@ -41,7 +41,7 @@ MEM_LIMIT=4294967296
 # on dev connect to the same network as off-server
 COMMON_NET_NAME=po_default
 
-# Sentry DNS for bug tracking
+# Sentry DNS for bug tracking, used only in staging and production
 SENTRY_DNS=
 
 # Log level to use, DEBUG by default in dev

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -28,6 +28,12 @@ def import_data(
         file_okay=True,
         exists=True,
     ),
+    index_id: Optional[str] = typer.Option(
+        default=None,
+        help="Each index has its own configuration in the configuration file, "
+        "and the ID is used to know which index to use. "
+        "If there is only one index, this option is not needed.",
+    ),
 ):
     """Import data into Elasticsearch."""
     import time
@@ -46,10 +52,16 @@ def import_data(
     start_time = time.perf_counter()
     check_config_is_defined()
     global_config = cast(config.Config, config.CONFIG)
+    index_id, index_config = global_config.get_index_config(index_id)
+    if index_config is None:
+        raise typer.BadParameter(
+            "You must specify an index ID when there are multiple indices"
+        )
+
     run_full_import(
         input_path,
         num_processes,
-        global_config,
+        index_config,
         num_items=num_items,
     )
     end_time = time.perf_counter()
@@ -64,6 +76,12 @@ def import_taxonomies(
         dir_okay=False,
         file_okay=True,
         exists=True,
+    ),
+    index_id: Optional[str] = typer.Option(
+        default=None,
+        help="Each index has its own configuration in the configuration file, "
+        "and the ID is used to know which index to use. "
+        "If there is only one index, this option is not needed.",
     ),
 ):
     """Import taxonomies into Elasticsearch."""
@@ -82,9 +100,14 @@ def import_taxonomies(
 
     check_config_is_defined()
     global_config = cast(config.Config, config.CONFIG)
+    index_id, index_config = global_config.get_index_config(index_id)
+    if index_config is None:
+        raise typer.BadParameter(
+            "You must specify an index ID when there are multiple indices"
+        )
 
     start_time = time.perf_counter()
-    perform_taxonomy_import(global_config)
+    perform_taxonomy_import(index_config)
     end_time = time.perf_counter()
     logger.info("Import time: %s seconds", end_time - start_time)
 

--- a/app/indexing.py
+++ b/app/indexing.py
@@ -12,6 +12,7 @@ from app.config import (
     Config,
     FieldConfig,
     FieldType,
+    IndexConfig,
     TaxonomyConfig,
     TaxonomySourceConfig,
 )
@@ -263,7 +264,7 @@ class DocumentProcessor:
     into a dict that is ready to be indexed by Elasticsearch.
     """
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: IndexConfig) -> None:
         self.config = config
         self.supported_langs = config.get_supported_langs()
         self.taxonomy_langs = config.get_taxonomy_langs()
@@ -339,7 +340,7 @@ class DocumentProcessor:
         return inputs
 
 
-def generate_mapping_object(config: Config) -> Mapping:
+def generate_mapping_object(config: IndexConfig) -> Mapping:
     mapping = Mapping()
     supported_langs = config.supported_langs
     taxonomy_langs = config.taxonomy.exported_langs
@@ -356,7 +357,7 @@ def generate_mapping_object(config: Config) -> Mapping:
     return mapping
 
 
-def generate_index_object(index_name: str, config: Config) -> Index:
+def generate_index_object(index_name: str, config: IndexConfig) -> Index:
     index = Index(index_name)
     index.settings(
         number_of_shards=config.index.number_of_shards,
@@ -367,7 +368,7 @@ def generate_index_object(index_name: str, config: Config) -> Index:
     return index
 
 
-def generate_taxonomy_mapping_object(config: Config) -> Mapping:
+def generate_taxonomy_mapping_object(config: IndexConfig) -> Mapping:
     mapping = Mapping()
     supported_langs = config.supported_langs
     mapping.field("id", dsl_field.Keyword(required=True))
@@ -395,7 +396,7 @@ def generate_taxonomy_mapping_object(config: Config) -> Mapping:
     return mapping
 
 
-def generate_taxonomy_index_object(index_name: str, config: Config) -> Index:
+def generate_taxonomy_index_object(index_name: str, config: IndexConfig) -> Index:
     index = Index(index_name)
     taxonomy_index_config = config.taxonomy.index
     index.settings(

--- a/app/postprocessing.py
+++ b/app/postprocessing.py
@@ -1,12 +1,12 @@
 from elasticsearch_dsl.response import Response
 
 from app._types import JSONType
-from app.config import Config, FieldType
+from app.config import FieldType, IndexConfig
 from app.utils import load_class_object_from_string
 
 
 class BaseResultProcessor:
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: IndexConfig) -> None:
         self.config = config
 
     def process(self, response: Response, projection: set[str] | None) -> JSONType:
@@ -46,10 +46,10 @@ class BaseResultProcessor:
         return result
 
 
-def load_result_processor(config: Config) -> BaseResultProcessor | None:
+def load_result_processor(config: IndexConfig) -> BaseResultProcessor | None:
     """Load the result processor class from the config.
 
-    :param config: the config object
+    :param config: the index configuration to use
     :return: the initialized result processor
     """
     result_processor_cls = (

--- a/config_schema.json
+++ b/config_schema.json
@@ -1,5 +1,43 @@
 {
     "$defs": {
+        "ESIndexConfig": {
+            "properties": {
+                "name": {
+                    "description": "name of the index alias to use",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "id_field_name": {
+                    "description": "name of the field to use for `_id`",
+                    "title": "Id Field Name",
+                    "type": "string"
+                },
+                "last_modified_field_name": {
+                    "description": "name of the field containing the date of last modification, used for incremental updates using Redis queues. The field value must be an int/float representing the timestamp.",
+                    "title": "Last Modified Field Name",
+                    "type": "string"
+                },
+                "number_of_shards": {
+                    "default": 4,
+                    "description": "number of shards to use for the index",
+                    "title": "Number Of Shards",
+                    "type": "integer"
+                },
+                "number_of_replicas": {
+                    "default": 1,
+                    "description": "number of replicas to use for the index",
+                    "title": "Number Of Replicas",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "name",
+                "id_field_name",
+                "last_modified_field_name"
+            ],
+            "title": "ESIndexConfig",
+            "type": "object"
+        },
         "FieldConfig": {
             "properties": {
                 "name": {
@@ -103,38 +141,125 @@
         },
         "IndexConfig": {
             "properties": {
-                "name": {
-                    "description": "name of the index alias to use",
-                    "title": "Name",
+                "index": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/ESIndexConfig"
+                        }
+                    ],
+                    "description": "configuration of the Elasticsearch index"
+                },
+                "fields": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/FieldConfig"
+                    },
+                    "description": "configuration of all fields in the index, keys are field names and values contain the field configuration",
+                    "title": "Fields",
+                    "type": "object"
+                },
+                "split_separator": {
+                    "default": ",",
+                    "description": "separator to use when splitting values, for fields that have split=True",
+                    "title": "Split Separator",
                     "type": "string"
                 },
-                "id_field_name": {
-                    "description": "name of the field to use for `_id`",
-                    "title": "Id Field Name",
+                "lang_separator": {
+                    "default": "_",
+                    "description": "for `text_lang` FieldType, the separator between the name of the field and the language code, ex: product_name_it if lang_separator=\"_\"",
+                    "title": "Lang Separator",
                     "type": "string"
                 },
-                "last_modified_field_name": {
-                    "description": "name of the field containing the date of last modification, used for incremental updates using Redis queues. The field value must be an int/float representing the timestamp.",
-                    "title": "Last Modified Field Name",
+                "taxonomy": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/TaxonomyConfig"
+                        }
+                    ],
+                    "description": "configuration of the taxonomies used"
+                },
+                "supported_langs": {
+                    "description": "A list of all supported languages, it is used to build index mapping",
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Supported Langs",
+                    "type": "array"
+                },
+                "document_fetcher": {
+                    "description": "The full qualified reference to the document fetcher, i.e. the class responsible from fetching the document using the document ID present in the Redis Stream.",
+                    "examples": [
+                        "app.openfoodfacts.DocumentFetcher"
+                    ],
+                    "title": "Document Fetcher",
                     "type": "string"
                 },
-                "number_of_shards": {
-                    "default": 4,
-                    "description": "number of shards to use for the index",
-                    "title": "Number Of Shards",
-                    "type": "integer"
+                "preprocessor": {
+                    "anyOf": [
+                        {
+                            "description": "The full qualified reference to the preprocessor to use before data import. This is used to adapt the data schema or to add search-a-licious specific fields for example.",
+                            "examples": [
+                                "app.openfoodfacts.DocumentPreprocessor"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Preprocessor"
                 },
-                "number_of_replicas": {
-                    "default": 1,
-                    "description": "number of replicas to use for the index",
-                    "title": "Number Of Replicas",
-                    "type": "integer"
+                "result_processor": {
+                    "anyOf": [
+                        {
+                            "description": "The full qualified reference to the elasticsearch result processor to use after search query to Elasticsearch. This is used to add custom fields for example.",
+                            "examples": [
+                                "app.openfoodfacts.ResultProcessor"
+                            ],
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Result Processor"
+                },
+                "match_phrase_boost": {
+                    "default": 2.0,
+                    "description": "How much we boost exact matches on individual fields",
+                    "title": "Match Phrase Boost",
+                    "type": "number"
+                },
+                "document_denylist": {
+                    "description": "list of documents IDs to ignore",
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "Document Denylist",
+                    "type": "array",
+                    "uniqueItems": true
+                },
+                "redis_stream_name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "description": "name of the Redis stream to read from when listening to document updates. If not provided, document updates won't be listened to for this index.",
+                    "title": "Redis Stream Name"
                 }
             },
             "required": [
-                "name",
-                "id_field_name",
-                "last_modified_field_name"
+                "index",
+                "fields",
+                "taxonomy",
+                "supported_langs",
+                "document_fetcher"
             ],
             "title": "IndexConfig",
             "type": "object"
@@ -177,7 +302,6 @@
         "TaxonomyIndexConfig": {
             "properties": {
                 "name": {
-                    "default": "taxonomy",
                     "description": "name of the taxonomy index alias to use",
                     "title": "Name",
                     "type": "string"
@@ -195,6 +319,9 @@
                     "type": "integer"
                 }
             },
+            "required": [
+                "name"
+            ],
             "title": "TaxonomyIndexConfig",
             "type": "object"
         },
@@ -223,112 +350,23 @@
         }
     },
     "properties": {
-        "index": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/IndexConfig"
-                }
-            ],
-            "description": "configuration of the index"
-        },
-        "fields": {
+        "indices": {
             "additionalProperties": {
-                "$ref": "#/$defs/FieldConfig"
+                "$ref": "#/$defs/IndexConfig"
             },
-            "description": "configuration of all fields in the index, keys are field names and values contain the field configuration",
-            "title": "Fields",
+            "description": "configuration of indices. The key is the ID of the index that can be referenced at query time. One index corresponds to a specific set of documents and can be queried independently.",
+            "title": "Indices",
             "type": "object"
         },
-        "split_separator": {
-            "default": ",",
-            "description": "separator to use when splitting values, for fields that have split=True",
-            "title": "Split Separator",
+        "default_index": {
+            "description": "the default index to use when no index is specified in the query",
+            "title": "Default Index",
             "type": "string"
-        },
-        "lang_separator": {
-            "default": "_",
-            "description": "for `text_lang` FieldType, the separator between the name of the field and the language code, ex: product_name_it if lang_separator=\"_\"",
-            "title": "Lang Separator",
-            "type": "string"
-        },
-        "taxonomy": {
-            "allOf": [
-                {
-                    "$ref": "#/$defs/TaxonomyConfig"
-                }
-            ],
-            "description": "configuration of the taxonomies used"
-        },
-        "supported_langs": {
-            "description": "A list of all supported languages, it is used to build index mapping",
-            "items": {
-                "type": "string"
-            },
-            "title": "Supported Langs",
-            "type": "array"
-        },
-        "document_fetcher": {
-            "description": "The full qualified reference to the document fetcher, i.e. the class responsible from fetching the document using the document ID present in the Redis Stream.",
-            "examples": [
-                "app.openfoodfacts.DocumentFetcher"
-            ],
-            "title": "Document Fetcher",
-            "type": "string"
-        },
-        "preprocessor": {
-            "anyOf": [
-                {
-                    "description": "The full qualified reference to the preprocessor to use before data import. This is used to adapt the data schema or to add search-a-licious specific fields for example.",
-                    "examples": [
-                        "app.openfoodfacts.DocumentPreprocessor"
-                    ],
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null,
-            "title": "Preprocessor"
-        },
-        "result_processor": {
-            "anyOf": [
-                {
-                    "description": "The full qualified reference to the elasticsearch result processor to use after search query to Elasticsearch. This is used to add custom fields for example.",
-                    "examples": [
-                        "app.openfoodfacts.ResultProcessor"
-                    ],
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null,
-            "title": "Result Processor"
-        },
-        "match_phrase_boost": {
-            "default": 2.0,
-            "description": "How much we boost exact matches on individual fields",
-            "title": "Match Phrase Boost",
-            "type": "number"
-        },
-        "document_denylist": {
-            "description": "list of documents IDs to ignore",
-            "items": {
-                "type": "string"
-            },
-            "title": "Document Denylist",
-            "type": "array",
-            "uniqueItems": true
         }
     },
     "required": [
-        "index",
-        "fields",
-        "taxonomy",
-        "supported_langs",
-        "document_fetcher"
+        "indices",
+        "default_index"
     ],
     "title": "JSON schema for search-a-licious configuration file",
     "type": "object",

--- a/data/config/openfoodfacts.yml
+++ b/data/config/openfoodfacts.yml
@@ -1,360 +1,365 @@
-index:
-  id_field_name: code
-  last_modified_field_name: last_modified_t
-  name: openfoodfacts
-  number_of_replicas: 1
-  number_of_shards: 4
-fields:
-  code:
-    required: true
-    type: keyword
-  obsolete:
-    required: true
-    type: bool
-  product_name:
-    full_text_search: true
-    type: text_lang
-  generic_name:
-    full_text_search: true
-    type: text_lang
-  abbreviated_product_name:
-    type: text_lang
-  categories:
-    full_text_search: true
-    input_field: categories_tags
-    taxonomy_name: category
-    type: taxonomy
-  labels:
-    full_text_search: true
-    input_field: labels_tags
-    taxonomy_name: label
-    type: taxonomy
-  brands:
-    full_text_search: true
-    split: true
-    type: text
-  brands_tags:
-    type: keyword
-    bucket_agg: true
-  stores:
-    split: true
-    type: text
-  emb_codes:
-    split: true
-    type: text
-  lang:
-    type: keyword
-    bucket_agg: true
-  lc:
-    type: keyword
-  owner:
-    type: keyword
-    bucket_agg: true
-  quantity:
-    type: text
-  categories_tags:
-    type: keyword
-    bucket_agg: true
-  labels_tags:
-    type: keyword
-    bucket_agg: true
-  countries_tags:
-    type: keyword
-    bucket_agg: true
-  states_tags:
-    type: keyword
-    bucket_agg: true
-  origins_tags:
-    type: keyword
-  ingredients_tags:
-    type: keyword
-  unique_scans_n:
-    type: integer
-  scans_n:
-    type: integer
-  nutrition_grades:
-    type: keyword
-    bucket_agg: true
-  ecoscore_grade:
-    type: keyword
-    bucket_agg: true
-  nova_groups:
-    type: keyword
-    bucket_agg: true
-  last_modified_t:
-    type: date
-  created_t:
-    type: date
-  images:
-    type: disabled
-  additives_n:
-    type: integer
-  allergens_tags:
-    type: keyword
-  ecoscore_data:
-    type: disabled
-  ecoscore_score:
-    type: integer
-  forest_footprint_data:
-    type: disabled
-  ingredients_analysis_tags:
-    type: keyword
-  ingredients_n:
-    type: integer
-  nova_group:
-    type: integer
-  nutrient_levels:
-    type: disabled
-  nutriments:
-    type: object
-  nutriscore_data:
-    type: disabled
-  nutriscore_grade:
-    type: keyword
-  traces_tags:
-    type: keyword
-  unknown_ingredients_n:
-    type: integer
-  popularity_key:
-    type: long
-  nutriscore_score:
-    type: integer
-  completeness:
-    type: float
-document_denylist:
-- '8901552007122'
-lang_separator: _
-match_phrase_boost: 2.0
-preprocessor: app.openfoodfacts.DocumentPreprocessor
-document_fetcher: app.openfoodfacts.DocumentFetcher
-result_processor: app.openfoodfacts.ResultProcessor
-split_separator: ','
-taxonomy:
-  sources:
-  - name: category
-    url: https://static.openfoodfacts.org/data/taxonomies/categories.full.json
-  - name: label
-    url: https://static.openfoodfacts.org/data/taxonomies/labels.full.json
-  - name: additive
-    url: https://static.openfoodfacts.org/data/taxonomies/additives.full.json
-  - name: allergen
-    url: https://static.openfoodfacts.org/data/taxonomies/allergens.full.json
-  - name: amino_acid
-    url: https://static.openfoodfacts.org/data/taxonomies/amino_acids.full.json
-  - name: country
-    url: https://static.openfoodfacts.org/data/taxonomies/countries.full.json
-  - name: data_quality
-    url: https://static.openfoodfacts.org/data/taxonomies/data_quality.full.json
-  - name: food_group
-    url: https://static.openfoodfacts.org/data/taxonomies/food_groups.full.json
-  - name: improvement
-    url: https://static.openfoodfacts.org/data/taxonomies/improvements.full.json
-  - name: ingredient
-    url: https://static.openfoodfacts.org/data/taxonomies/ingredients.full.json
-  - name: ingredients_analysis
-    url: https://static.openfoodfacts.org/data/taxonomies/ingredients_analysis.full.json
-  - name: ingredients_processing
-    url: https://static.openfoodfacts.org/data/taxonomies/ingredients_processing.full.json
-  - name: language
-    url: https://static.openfoodfacts.org/data/taxonomies/languages.full.json
-  - name: mineral
-    url: https://static.openfoodfacts.org/data/taxonomies/minerals.full.json
-  - name: misc
-    url: https://static.openfoodfacts.org/data/taxonomies/misc.full.json
-  - name: nova_group
-    url: https://static.openfoodfacts.org/data/taxonomies/nova_groups.full.json
-  - name: nucleotide
-    url: https://static.openfoodfacts.org/data/taxonomies/nucleotides.full.json
-  - name: nutrient
-    url: https://static.openfoodfacts.org/data/taxonomies/nutrients.full.json
-  - name: origin
-    url: https://static.openfoodfacts.org/data/taxonomies/origins.full.json
-  - name: other_nutritional_substance
-    url: https://static.openfoodfacts.org/data/taxonomies/other_nutritional_substances.full.json
-  - name: packaging_material
-    url: https://static.openfoodfacts.org/data/taxonomies/packaging_materials.full.json
-  - name: packaging_recycling
-    url: https://static.openfoodfacts.org/data/taxonomies/packaging_recycling.full.json
-  - name: packaging_shape
-    url: https://static.openfoodfacts.org/data/taxonomies/packaging_shapes.full.json
-  - name: periods_after_opening
-    url: https://static.openfoodfacts.org/data/taxonomies/periods_after_opening.full.json
-  - name: preservation
-    url: https://static.openfoodfacts.org/data/taxonomies/preservation.full.json
-  - name: state
-    url: https://static.openfoodfacts.org/data/taxonomies/states.full.json
-  - name: vitamin
-    url: https://static.openfoodfacts.org/data/taxonomies/vitamins.full.json
-  - name: brand
-    url: https://static.openfoodfacts.org/data/taxonomies/brands.full.json
-  exported_langs:
-  - en
-  - fr
-  - es
-  - de
-  - it
-  - nl
-  index:
-    number_of_replicas: 1
-    number_of_shards: 4
-supported_langs:
-- aa
-- ab
-- ae
-- af
-- ak
-- am
-- ar
-- as
-- at
-- au
-- ay
-- az
-- be
-- bg
-- bi
-- bn
-- br
-- bs
-- ca
-- ch
-- co
-- cs
-- cu
-- cy
-- da
-- de
-- dv
-- dz
-- el
-- en
-- eo
-- es
-- et
-- eu
-- fa
-- fi
-- fj
-- fo
-- fr
-- fy
-- ga
-- gb
-- gd
-- gl
-- gn
-- gp
-- gu
-- gv
-- ha
-- he
-- hi
-- hk
-- ho
-- hr
-- ht
-- hu
-- hy
-- hz
-- id
-- in
-- io
-- is
-- it
-- iw
-- ja
-- jp
-- jv
-- ka
-- kk
-- kl
-- km
-- kn
-- ko
-- ku
-- ky
-- la
-- lb
-- lc
-- ln
-- lo
-- lt
-- lu
-- lv
-- mg
-- mh
-- mi
-- mk
-- ml
-- mn
-- mo
-- mr
-- ms
-- mt
-- my
-- na
-- nb
-- nd
-- ne
-- nl
-- nn
-- 'no'
-- nr
-- ny
-- oc
-- om
-- pa
-- pl
-- ps
-- pt
-- qq
-- qu
-- re
-- rm
-- rn
-- ro
-- rs
-- ru
-- rw
-- sd
-- se
-- sg
-- sh
-- si
-- sk
-- sl
-- sm
-- sn
-- so
-- sq
-- sr
-- ss
-- st
-- sv
-- sw
-- ta
-- te
-- tg
-- th
-- ti
-- tk
-- tl
-- tn
-- to
-- tr
-- ts
-- ug
-- uk
-- ur
-- us
-- uz
-- ve
-- vi
-- wa
-- wo
-- xh
-- xx
-- yi
-- yo
-- zh
-- zu
+indices:
+  "off":
+    index:
+      id_field_name: code
+      last_modified_field_name: last_modified_t
+      name: openfoodfacts
+      number_of_replicas: 1
+      number_of_shards: 4
+    fields:
+      code:
+        required: true
+        type: keyword
+      obsolete:
+        required: true
+        type: bool
+      product_name:
+        full_text_search: true
+        type: text_lang
+      generic_name:
+        full_text_search: true
+        type: text_lang
+      abbreviated_product_name:
+        type: text_lang
+      categories:
+        full_text_search: true
+        input_field: categories_tags
+        taxonomy_name: category
+        type: taxonomy
+      labels:
+        full_text_search: true
+        input_field: labels_tags
+        taxonomy_name: label
+        type: taxonomy
+      brands:
+        full_text_search: true
+        split: true
+        type: text
+      brands_tags:
+        type: keyword
+        bucket_agg: true
+      stores:
+        split: true
+        type: text
+      emb_codes:
+        split: true
+        type: text
+      lang:
+        type: keyword
+        bucket_agg: true
+      lc:
+        type: keyword
+      owner:
+        type: keyword
+        bucket_agg: true
+      quantity:
+        type: text
+      categories_tags:
+        type: keyword
+        bucket_agg: true
+      labels_tags:
+        type: keyword
+        bucket_agg: true
+      countries_tags:
+        type: keyword
+        bucket_agg: true
+      states_tags:
+        type: keyword
+        bucket_agg: true
+      origins_tags:
+        type: keyword
+      ingredients_tags:
+        type: keyword
+      unique_scans_n:
+        type: integer
+      scans_n:
+        type: integer
+      nutrition_grades:
+        type: keyword
+        bucket_agg: true
+      ecoscore_grade:
+        type: keyword
+        bucket_agg: true
+      nova_groups:
+        type: keyword
+        bucket_agg: true
+      last_modified_t:
+        type: date
+      created_t:
+        type: date
+      images:
+        type: disabled
+      additives_n:
+        type: integer
+      allergens_tags:
+        type: keyword
+      ecoscore_data:
+        type: disabled
+      ecoscore_score:
+        type: integer
+      forest_footprint_data:
+        type: disabled
+      ingredients_analysis_tags:
+        type: keyword
+      ingredients_n:
+        type: integer
+      nova_group:
+        type: integer
+      nutrient_levels:
+        type: disabled
+      nutriments:
+        type: object
+      nutriscore_data:
+        type: disabled
+      nutriscore_grade:
+        type: keyword
+      traces_tags:
+        type: keyword
+      unknown_ingredients_n:
+        type: integer
+      popularity_key:
+        type: long
+      nutriscore_score:
+        type: integer
+      completeness:
+        type: float
+    document_denylist:
+    - '8901552007122'
+    lang_separator: _
+    match_phrase_boost: 2.0
+    preprocessor: app.openfoodfacts.DocumentPreprocessor
+    document_fetcher: app.openfoodfacts.DocumentFetcher
+    result_processor: app.openfoodfacts.ResultProcessor
+    split_separator: ','
+    redis_stream_name: product_updates_off
+    taxonomy:
+      sources:
+      - name: category
+        url: https://static.openfoodfacts.org/data/taxonomies/categories.full.json
+      - name: label
+        url: https://static.openfoodfacts.org/data/taxonomies/labels.full.json
+      - name: additive
+        url: https://static.openfoodfacts.org/data/taxonomies/additives.full.json
+      - name: allergen
+        url: https://static.openfoodfacts.org/data/taxonomies/allergens.full.json
+      - name: amino_acid
+        url: https://static.openfoodfacts.org/data/taxonomies/amino_acids.full.json
+      - name: country
+        url: https://static.openfoodfacts.org/data/taxonomies/countries.full.json
+      - name: data_quality
+        url: https://static.openfoodfacts.org/data/taxonomies/data_quality.full.json
+      - name: food_group
+        url: https://static.openfoodfacts.org/data/taxonomies/food_groups.full.json
+      - name: improvement
+        url: https://static.openfoodfacts.org/data/taxonomies/improvements.full.json
+      - name: ingredient
+        url: https://static.openfoodfacts.org/data/taxonomies/ingredients.full.json
+      - name: ingredients_analysis
+        url: https://static.openfoodfacts.org/data/taxonomies/ingredients_analysis.full.json
+      - name: ingredients_processing
+        url: https://static.openfoodfacts.org/data/taxonomies/ingredients_processing.full.json
+      - name: language
+        url: https://static.openfoodfacts.org/data/taxonomies/languages.full.json
+      - name: mineral
+        url: https://static.openfoodfacts.org/data/taxonomies/minerals.full.json
+      - name: misc
+        url: https://static.openfoodfacts.org/data/taxonomies/misc.full.json
+      - name: nova_group
+        url: https://static.openfoodfacts.org/data/taxonomies/nova_groups.full.json
+      - name: nucleotide
+        url: https://static.openfoodfacts.org/data/taxonomies/nucleotides.full.json
+      - name: nutrient
+        url: https://static.openfoodfacts.org/data/taxonomies/nutrients.full.json
+      - name: origin
+        url: https://static.openfoodfacts.org/data/taxonomies/origins.full.json
+      - name: other_nutritional_substance
+        url: https://static.openfoodfacts.org/data/taxonomies/other_nutritional_substances.full.json
+      - name: packaging_material
+        url: https://static.openfoodfacts.org/data/taxonomies/packaging_materials.full.json
+      - name: packaging_recycling
+        url: https://static.openfoodfacts.org/data/taxonomies/packaging_recycling.full.json
+      - name: packaging_shape
+        url: https://static.openfoodfacts.org/data/taxonomies/packaging_shapes.full.json
+      - name: periods_after_opening
+        url: https://static.openfoodfacts.org/data/taxonomies/periods_after_opening.full.json
+      - name: preservation
+        url: https://static.openfoodfacts.org/data/taxonomies/preservation.full.json
+      - name: state
+        url: https://static.openfoodfacts.org/data/taxonomies/states.full.json
+      - name: vitamin
+        url: https://static.openfoodfacts.org/data/taxonomies/vitamins.full.json
+      - name: brand
+        url: https://static.openfoodfacts.org/data/taxonomies/brands.full.json
+      exported_langs:
+      - en
+      - fr
+      - es
+      - de
+      - it
+      - nl
+      index:
+        number_of_replicas: 1
+        number_of_shards: 4
+        name: off_taxonomy
+    supported_langs:
+    - aa
+    - ab
+    - ae
+    - af
+    - ak
+    - am
+    - ar
+    - as
+    - at
+    - au
+    - ay
+    - az
+    - be
+    - bg
+    - bi
+    - bn
+    - br
+    - bs
+    - ca
+    - ch
+    - co
+    - cs
+    - cu
+    - cy
+    - da
+    - de
+    - dv
+    - dz
+    - el
+    - en
+    - eo
+    - es
+    - et
+    - eu
+    - fa
+    - fi
+    - fj
+    - fo
+    - fr
+    - fy
+    - ga
+    - gb
+    - gd
+    - gl
+    - gn
+    - gp
+    - gu
+    - gv
+    - ha
+    - he
+    - hi
+    - hk
+    - ho
+    - hr
+    - ht
+    - hu
+    - hy
+    - hz
+    - id
+    - in
+    - io
+    - is
+    - it
+    - iw
+    - ja
+    - jp
+    - jv
+    - ka
+    - kk
+    - kl
+    - km
+    - kn
+    - ko
+    - ku
+    - ky
+    - la
+    - lb
+    - lc
+    - ln
+    - lo
+    - lt
+    - lu
+    - lv
+    - mg
+    - mh
+    - mi
+    - mk
+    - ml
+    - mn
+    - mo
+    - mr
+    - ms
+    - mt
+    - my
+    - na
+    - nb
+    - nd
+    - ne
+    - nl
+    - nn
+    - 'no'
+    - nr
+    - ny
+    - oc
+    - om
+    - pa
+    - pl
+    - ps
+    - pt
+    - qq
+    - qu
+    - re
+    - rm
+    - rn
+    - ro
+    - rs
+    - ru
+    - rw
+    - sd
+    - se
+    - sg
+    - sh
+    - si
+    - sk
+    - sl
+    - sm
+    - sn
+    - so
+    - sq
+    - sr
+    - ss
+    - st
+    - sv
+    - sw
+    - ta
+    - te
+    - tg
+    - th
+    - ti
+    - tk
+    - tl
+    - tn
+    - to
+    - tr
+    - ts
+    - ug
+    - uk
+    - ur
+    - us
+    - uz
+    - ve
+    - vi
+    - wa
+    - wo
+    - xh
+    - xx
+    - yi
+    - yo
+    - zh
+    - zu
+default_index: "off"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,7 +11,14 @@ DEFAULT_CONFIG_PATH = DATA_DIR / "openfoodfacts_config.yml"
 
 @pytest.fixture
 def default_config():
-    """Fixture that returns default Open Food Facts configuration for tests."""
+    """Fixture that returns default Open Food Facts index configuration for
+    tests."""
+    yield Config.from_yaml(DEFAULT_CONFIG_PATH).indices["off"]
+
+
+@pytest.fixture
+def default_global_config():
+    """Fixture that returns default global configuration for tests."""
     yield Config.from_yaml(DEFAULT_CONFIG_PATH)
 
 

--- a/tests/unit/data/openfoodfacts_config.yml
+++ b/tests/unit/data/openfoodfacts_config.yml
@@ -1,360 +1,365 @@
-index:
-  id_field_name: code
-  last_modified_field_name: last_modified_t
-  name: openfoodfacts
-  number_of_replicas: 1
-  number_of_shards: 4
-fields:
-  code:
-    required: true
-    type: keyword
-  obsolete:
-    required: true
-    type: bool
-  product_name:
-    full_text_search: true
-    type: text_lang
-  generic_name:
-    full_text_search: true
-    type: text_lang
-  abbreviated_product_name:
-    type: text_lang
-  categories:
-    full_text_search: true
-    input_field: categories_tags
-    taxonomy_name: category
-    type: taxonomy
-  labels:
-    full_text_search: true
-    input_field: labels_tags
-    taxonomy_name: label
-    type: taxonomy
-  brands:
-    full_text_search: true
-    split: true
-    type: text
-  brands_tags:
-    type: keyword
-    bucket_agg: true
-  stores:
-    split: true
-    type: text
-  emb_codes:
-    split: true
-    type: text
-  lang:
-    type: keyword
-    bucket_agg: true
-  lc:
-    type: keyword
-  owner:
-    type: keyword
-    bucket_agg: true
-  quantity:
-    type: text
-  categories_tags:
-    type: keyword
-    bucket_agg: true
-  labels_tags:
-    type: keyword
-    bucket_agg: true
-  countries_tags:
-    type: keyword
-    bucket_agg: true
-  states_tags:
-    type: keyword
-    bucket_agg: true
-  origins_tags:
-    type: keyword
-  ingredients_tags:
-    type: keyword
-  unique_scans_n:
-    type: integer
-  scans_n:
-    type: integer
-  nutrition_grades:
-    type: keyword
-    bucket_agg: true
-  ecoscore_grade:
-    type: keyword
-    bucket_agg: true
-  nova_groups:
-    type: keyword
-    bucket_agg: true
-  last_modified_t:
-    type: date
-  created_t:
-    type: date
-  images:
-    type: disabled
-  additives_n:
-    type: integer
-  allergens_tags:
-    type: keyword
-  ecoscore_data:
-    type: disabled
-  ecoscore_score:
-    type: integer
-  forest_footprint_data:
-    type: disabled
-  ingredients_analysis_tags:
-    type: keyword
-  ingredients_n:
-    type: integer
-  nova_group:
-    type: integer
-  nutrient_levels:
-    type: disabled
-  nutriments:
-    type: object
-  nutriscore_data:
-    type: disabled
-  nutriscore_grade:
-    type: keyword
-  traces_tags:
-    type: keyword
-  unknown_ingredients_n:
-    type: integer
-  popularity_key:
-    type: integer
-  nutriscore_score:
-    type: integer
-  completeness:
-    type: float
-document_denylist:
-- '8901552007122'
-lang_separator: _
-match_phrase_boost: 2.0
-preprocessor: app.openfoodfacts.DocumentPreprocessor
-document_fetcher: app.openfoodfacts.DocumentFetcher
-result_processor: app.openfoodfacts.ResultProcessor
-split_separator: ','
-taxonomy:
-  sources:
-  - name: category
-    url: https://static.openfoodfacts.org/data/taxonomies/categories.full.json
-  - name: label
-    url: https://static.openfoodfacts.org/data/taxonomies/labels.full.json
-  - name: additive
-    url: https://static.openfoodfacts.org/data/taxonomies/additives.full.json
-  - name: allergen
-    url: https://static.openfoodfacts.org/data/taxonomies/allergens.full.json
-  - name: amino_acid
-    url: https://static.openfoodfacts.org/data/taxonomies/amino_acids.full.json
-  - name: country
-    url: https://static.openfoodfacts.org/data/taxonomies/countries.full.json
-  - name: data_quality
-    url: https://static.openfoodfacts.org/data/taxonomies/data_quality.full.json
-  - name: food_group
-    url: https://static.openfoodfacts.org/data/taxonomies/food_groups.full.json
-  - name: improvement
-    url: https://static.openfoodfacts.org/data/taxonomies/improvements.full.json
-  - name: ingredient
-    url: https://static.openfoodfacts.org/data/taxonomies/ingredients.full.json
-  - name: ingredients_analysis
-    url: https://static.openfoodfacts.org/data/taxonomies/ingredients_analysis.full.json
-  - name: ingredients_processing
-    url: https://static.openfoodfacts.org/data/taxonomies/ingredients_processing.full.json
-  - name: language
-    url: https://static.openfoodfacts.org/data/taxonomies/languages.full.json
-  - name: mineral
-    url: https://static.openfoodfacts.org/data/taxonomies/minerals.full.json
-  - name: misc
-    url: https://static.openfoodfacts.org/data/taxonomies/misc.full.json
-  - name: nova_group
-    url: https://static.openfoodfacts.org/data/taxonomies/nova_groups.full.json
-  - name: nucleotide
-    url: https://static.openfoodfacts.org/data/taxonomies/nucleotides.full.json
-  - name: nutrient
-    url: https://static.openfoodfacts.org/data/taxonomies/nutrients.full.json
-  - name: origin
-    url: https://static.openfoodfacts.org/data/taxonomies/origins.full.json
-  - name: other_nutritional_substance
-    url: https://static.openfoodfacts.org/data/taxonomies/other_nutritional_substances.full.json
-  - name: packaging_material
-    url: https://static.openfoodfacts.org/data/taxonomies/packaging_materials.full.json
-  - name: packaging_recycling
-    url: https://static.openfoodfacts.org/data/taxonomies/packaging_recycling.full.json
-  - name: packaging_shape
-    url: https://static.openfoodfacts.org/data/taxonomies/packaging_shapes.full.json
-  - name: periods_after_opening
-    url: https://static.openfoodfacts.org/data/taxonomies/periods_after_opening.full.json
-  - name: preservation
-    url: https://static.openfoodfacts.org/data/taxonomies/preservation.full.json
-  - name: state
-    url: https://static.openfoodfacts.org/data/taxonomies/states.full.json
-  - name: vitamin
-    url: https://static.openfoodfacts.org/data/taxonomies/vitamins.full.json
-  - name: brand
-    url: https://static.openfoodfacts.org/data/taxonomies/brands.full.json
-  exported_langs:
-  - en
-  - fr
-  - es
-  - de
-  - it
-  - nl
-  index:
-    number_of_replicas: 1
-    number_of_shards: 4
-supported_langs:
-- aa
-- ab
-- ae
-- af
-- ak
-- am
-- ar
-- as
-- at
-- au
-- ay
-- az
-- be
-- bg
-- bi
-- bn
-- br
-- bs
-- ca
-- ch
-- co
-- cs
-- cu
-- cy
-- da
-- de
-- dv
-- dz
-- el
-- en
-- eo
-- es
-- et
-- eu
-- fa
-- fi
-- fj
-- fo
-- fr
-- fy
-- ga
-- gb
-- gd
-- gl
-- gn
-- gp
-- gu
-- gv
-- ha
-- he
-- hi
-- hk
-- ho
-- hr
-- ht
-- hu
-- hy
-- hz
-- id
-- in
-- io
-- is
-- it
-- iw
-- ja
-- jp
-- jv
-- ka
-- kk
-- kl
-- km
-- kn
-- ko
-- ku
-- ky
-- la
-- lb
-- lc
-- ln
-- lo
-- lt
-- lu
-- lv
-- mg
-- mh
-- mi
-- mk
-- ml
-- mn
-- mo
-- mr
-- ms
-- mt
-- my
-- na
-- nb
-- nd
-- ne
-- nl
-- nn
-- 'no'
-- nr
-- ny
-- oc
-- om
-- pa
-- pl
-- ps
-- pt
-- qq
-- qu
-- re
-- rm
-- rn
-- ro
-- rs
-- ru
-- rw
-- sd
-- se
-- sg
-- sh
-- si
-- sk
-- sl
-- sm
-- sn
-- so
-- sq
-- sr
-- ss
-- st
-- sv
-- sw
-- ta
-- te
-- tg
-- th
-- ti
-- tk
-- tl
-- tn
-- to
-- tr
-- ts
-- ug
-- uk
-- ur
-- us
-- uz
-- ve
-- vi
-- wa
-- wo
-- xh
-- xx
-- yi
-- yo
-- zh
-- zu
+indices:
+  "off":
+    index:
+      id_field_name: code
+      last_modified_field_name: last_modified_t
+      name: openfoodfacts
+      number_of_replicas: 1
+      number_of_shards: 4
+    fields:
+      code:
+        required: true
+        type: keyword
+      obsolete:
+        required: true
+        type: bool
+      product_name:
+        full_text_search: true
+        type: text_lang
+      generic_name:
+        full_text_search: true
+        type: text_lang
+      abbreviated_product_name:
+        type: text_lang
+      categories:
+        full_text_search: true
+        input_field: categories_tags
+        taxonomy_name: category
+        type: taxonomy
+      labels:
+        full_text_search: true
+        input_field: labels_tags
+        taxonomy_name: label
+        type: taxonomy
+      brands:
+        full_text_search: true
+        split: true
+        type: text
+      brands_tags:
+        type: keyword
+        bucket_agg: true
+      stores:
+        split: true
+        type: text
+      emb_codes:
+        split: true
+        type: text
+      lang:
+        type: keyword
+        bucket_agg: true
+      lc:
+        type: keyword
+      owner:
+        type: keyword
+        bucket_agg: true
+      quantity:
+        type: text
+      categories_tags:
+        type: keyword
+        bucket_agg: true
+      labels_tags:
+        type: keyword
+        bucket_agg: true
+      countries_tags:
+        type: keyword
+        bucket_agg: true
+      states_tags:
+        type: keyword
+        bucket_agg: true
+      origins_tags:
+        type: keyword
+      ingredients_tags:
+        type: keyword
+      unique_scans_n:
+        type: integer
+      scans_n:
+        type: integer
+      nutrition_grades:
+        type: keyword
+        bucket_agg: true
+      ecoscore_grade:
+        type: keyword
+        bucket_agg: true
+      nova_groups:
+        type: keyword
+        bucket_agg: true
+      last_modified_t:
+        type: date
+      created_t:
+        type: date
+      images:
+        type: disabled
+      additives_n:
+        type: integer
+      allergens_tags:
+        type: keyword
+      ecoscore_data:
+        type: disabled
+      ecoscore_score:
+        type: integer
+      forest_footprint_data:
+        type: disabled
+      ingredients_analysis_tags:
+        type: keyword
+      ingredients_n:
+        type: integer
+      nova_group:
+        type: integer
+      nutrient_levels:
+        type: disabled
+      nutriments:
+        type: object
+      nutriscore_data:
+        type: disabled
+      nutriscore_grade:
+        type: keyword
+      traces_tags:
+        type: keyword
+      unknown_ingredients_n:
+        type: integer
+      popularity_key:
+        type: long
+      nutriscore_score:
+        type: integer
+      completeness:
+        type: float
+    document_denylist:
+    - '8901552007122'
+    lang_separator: _
+    match_phrase_boost: 2.0
+    preprocessor: app.openfoodfacts.DocumentPreprocessor
+    document_fetcher: app.openfoodfacts.DocumentFetcher
+    result_processor: app.openfoodfacts.ResultProcessor
+    split_separator: ','
+    redis_stream_name: product_updates_off
+    taxonomy:
+      sources:
+      - name: category
+        url: https://static.openfoodfacts.org/data/taxonomies/categories.full.json
+      - name: label
+        url: https://static.openfoodfacts.org/data/taxonomies/labels.full.json
+      - name: additive
+        url: https://static.openfoodfacts.org/data/taxonomies/additives.full.json
+      - name: allergen
+        url: https://static.openfoodfacts.org/data/taxonomies/allergens.full.json
+      - name: amino_acid
+        url: https://static.openfoodfacts.org/data/taxonomies/amino_acids.full.json
+      - name: country
+        url: https://static.openfoodfacts.org/data/taxonomies/countries.full.json
+      - name: data_quality
+        url: https://static.openfoodfacts.org/data/taxonomies/data_quality.full.json
+      - name: food_group
+        url: https://static.openfoodfacts.org/data/taxonomies/food_groups.full.json
+      - name: improvement
+        url: https://static.openfoodfacts.org/data/taxonomies/improvements.full.json
+      - name: ingredient
+        url: https://static.openfoodfacts.org/data/taxonomies/ingredients.full.json
+      - name: ingredients_analysis
+        url: https://static.openfoodfacts.org/data/taxonomies/ingredients_analysis.full.json
+      - name: ingredients_processing
+        url: https://static.openfoodfacts.org/data/taxonomies/ingredients_processing.full.json
+      - name: language
+        url: https://static.openfoodfacts.org/data/taxonomies/languages.full.json
+      - name: mineral
+        url: https://static.openfoodfacts.org/data/taxonomies/minerals.full.json
+      - name: misc
+        url: https://static.openfoodfacts.org/data/taxonomies/misc.full.json
+      - name: nova_group
+        url: https://static.openfoodfacts.org/data/taxonomies/nova_groups.full.json
+      - name: nucleotide
+        url: https://static.openfoodfacts.org/data/taxonomies/nucleotides.full.json
+      - name: nutrient
+        url: https://static.openfoodfacts.org/data/taxonomies/nutrients.full.json
+      - name: origin
+        url: https://static.openfoodfacts.org/data/taxonomies/origins.full.json
+      - name: other_nutritional_substance
+        url: https://static.openfoodfacts.org/data/taxonomies/other_nutritional_substances.full.json
+      - name: packaging_material
+        url: https://static.openfoodfacts.org/data/taxonomies/packaging_materials.full.json
+      - name: packaging_recycling
+        url: https://static.openfoodfacts.org/data/taxonomies/packaging_recycling.full.json
+      - name: packaging_shape
+        url: https://static.openfoodfacts.org/data/taxonomies/packaging_shapes.full.json
+      - name: periods_after_opening
+        url: https://static.openfoodfacts.org/data/taxonomies/periods_after_opening.full.json
+      - name: preservation
+        url: https://static.openfoodfacts.org/data/taxonomies/preservation.full.json
+      - name: state
+        url: https://static.openfoodfacts.org/data/taxonomies/states.full.json
+      - name: vitamin
+        url: https://static.openfoodfacts.org/data/taxonomies/vitamins.full.json
+      - name: brand
+        url: https://static.openfoodfacts.org/data/taxonomies/brands.full.json
+      exported_langs:
+      - en
+      - fr
+      - es
+      - de
+      - it
+      - nl
+      index:
+        number_of_replicas: 1
+        number_of_shards: 4
+        name: off_taxonomy
+    supported_langs:
+    - aa
+    - ab
+    - ae
+    - af
+    - ak
+    - am
+    - ar
+    - as
+    - at
+    - au
+    - ay
+    - az
+    - be
+    - bg
+    - bi
+    - bn
+    - br
+    - bs
+    - ca
+    - ch
+    - co
+    - cs
+    - cu
+    - cy
+    - da
+    - de
+    - dv
+    - dz
+    - el
+    - en
+    - eo
+    - es
+    - et
+    - eu
+    - fa
+    - fi
+    - fj
+    - fo
+    - fr
+    - fy
+    - ga
+    - gb
+    - gd
+    - gl
+    - gn
+    - gp
+    - gu
+    - gv
+    - ha
+    - he
+    - hi
+    - hk
+    - ho
+    - hr
+    - ht
+    - hu
+    - hy
+    - hz
+    - id
+    - in
+    - io
+    - is
+    - it
+    - iw
+    - ja
+    - jp
+    - jv
+    - ka
+    - kk
+    - kl
+    - km
+    - kn
+    - ko
+    - ku
+    - ky
+    - la
+    - lb
+    - lc
+    - ln
+    - lo
+    - lt
+    - lu
+    - lv
+    - mg
+    - mh
+    - mi
+    - mk
+    - ml
+    - mn
+    - mo
+    - mr
+    - ms
+    - mt
+    - my
+    - na
+    - nb
+    - nd
+    - ne
+    - nl
+    - nn
+    - 'no'
+    - nr
+    - ny
+    - oc
+    - om
+    - pa
+    - pl
+    - ps
+    - pt
+    - qq
+    - qu
+    - re
+    - rm
+    - rn
+    - ro
+    - rs
+    - ru
+    - rw
+    - sd
+    - se
+    - sg
+    - sh
+    - si
+    - sk
+    - sl
+    - sm
+    - sn
+    - so
+    - sq
+    - sr
+    - ss
+    - st
+    - sv
+    - sw
+    - ta
+    - te
+    - tg
+    - th
+    - ti
+    - tk
+    - tl
+    - tn
+    - to
+    - tr
+    - ts
+    - ug
+    - uk
+    - ur
+    - us
+    - uz
+    - ve
+    - vi
+    - wa
+    - wo
+    - xh
+    - xx
+    - yi
+    - yo
+    - zh
+    - zu
+default_index: "off"

--- a/tests/unit/test_indexing.py
+++ b/tests/unit/test_indexing.py
@@ -70,7 +70,7 @@ taxonomy_config = TaxonomyConfig(
         )
     ],
     exported_langs=["en"],
-    index=TaxonomyIndexConfig(),
+    index=TaxonomyIndexConfig(name="off_taxonomy"),
 )
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -6,7 +6,7 @@ from luqum.elasticsearch import ElasticsearchQueryBuilder
 from luqum.parser import parser
 
 from app._types import JSONType
-from app.config import Config
+from app.config import IndexConfig
 from app.query import (
     UnknownOperationRemover,
     build_search_query,
@@ -158,7 +158,7 @@ def test_build_search_query(
     page: int,
     sort_by: str | None,
     update_results: bool,
-    default_config: Config,
+    default_config: IndexConfig,
     default_filter_query_builder: ElasticsearchQueryBuilder,
 ):
     query = build_search_query(


### PR DESCRIPTION
Allow to index & search several independent collections using the `index_id` parameter.
A default index must be configured in the YAML configuration file.