### PR TITLE
fix: improve "npx playwright install-deps" in frontend/dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -31,8 +31,18 @@ RUN --mount=type=cache,id=search-a-licious-npm-cache,target=/home/node/.npm,mode
   npm install && \
   npx playwright install
 USER root
-RUN  --mount=type=cache,id=search-a-licious-apt-cache,target=/var/cache/apt \
-  npx playwright install-deps chromium
+# Install the dependencies for playwright with chromium
+# "npx playwright install-deps chromium" is broken on some hosts
+# (see https://github.com/microsoft/playwright/issues/11165)
+# We switched to direct "apt-get install" command
+# Dependencies listed with: "npx playwright install-deps chromium --dry-run"
+RUN apt-get update&& apt-get install -y --no-install-recommends libasound2 \
+  libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libcairo2 libcups2 libdbus-1-3 libdrm2 \
+  libgbm1 libglib2.0-0 libnspr4 libnss3 libpango-1.0-0 libwayland-client0 libx11-6 \
+  libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2 xvfb \
+  fonts-noto-color-emoji fonts-unifont libfontconfig1 libfreetype6 xfonts-cyrillic \
+  xfonts-scalable fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei \
+  fonts-tlwg-loma-otf fonts-freefont-ttf
 USER node
 # add local binaries to path
 ENV PATH /opt/search-a-licious/node_modules/.bin:$PATH

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 
 # builder is the node service, only used to build project in prod
-FROM node:lts as builder
+FROM node:lts-bullseye as builder
 ARG USER_UID
 ARG USER_GID
 RUN usermod --uid $USER_UID node && \
@@ -36,12 +36,13 @@ USER root
 # (see https://github.com/microsoft/playwright/issues/11165)
 # We switched to direct "apt-get install" command
 # Dependencies listed with: "npx playwright install-deps chromium --dry-run"
-RUN apt-get update&& apt-get install -y --no-install-recommends libasound2 \
-  libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libcairo2 libcups2 libdbus-1-3 libdrm2 \
-  libgbm1 libglib2.0-0 libnspr4 libnss3 libpango-1.0-0 libwayland-client0 libx11-6 \
-  libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2 xvfb \
-  fonts-noto-color-emoji fonts-unifont libfontconfig1 libfreetype6 xfonts-cyrillic \
-  xfonts-scalable fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei \
+RUN --mount=type=cache,id=search-a-licious-apt-cache,target=/var/cache/apt \
+  apt-get update&& apt-get install -y --no-install-recommends libasound2 \
+  libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libcairo2 libcups2 libdbus-1-3 \
+  libdrm2 libgbm1 libglib2.0-0 libnspr4 libnss3 libpango-1.0-0 libwayland-client0 \
+  libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 \
+  libxrandr2 xvfb fonts-noto-color-emoji fonts-unifont libfontconfig1 libfreetype6 \
+  xfonts-cyrillic xfonts-scalable fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei \
   fonts-tlwg-loma-otf fonts-freefont-ttf
 USER node
 # add local binaries to path


### PR DESCRIPTION

### What

`make build` was broken on my Linux Mint 21  because of this line `npm playwright install-deps chromium`.

The solution is to replace this line by an exhaustive `apt-get install`.