### PR TITLE
feat: hide charts when search is not launched

### DIFF
--- a/frontend/public/off.html
+++ b/frontend/public/off.html
@@ -335,7 +335,7 @@
                   </div>
 
                 </div>
-                <searchalicious-layout-page>
+                <searchalicious-layout-page search-name="off">
                   <div slot="col-1">
                     <!-- A form to input user preferences, to showcase personal sort -->
                     <div id="preferences_config_toggle">

--- a/frontend/src/layouts/search-layout-page.ts
+++ b/frontend/src/layouts/search-layout-page.ts
@@ -7,6 +7,7 @@ import {HIDE_STYLE} from '../styles';
 import {ContextConsumer} from '@lit/context';
 import {chartSideBarStateContext} from '../context';
 import {SearchaliciousResultCtlMixin} from '../mixins/search-results-ctl';
+import {refreshCharts} from '../utils/charts';
 
 /**
  * Component for the layout of the page
@@ -65,27 +66,24 @@ export class SearchLayoutPage extends SearchaliciousResultCtlMixin(
       if (state !== SideBarState.CLOSED) {
         // Refresh the charts when the sidebar is opened
         // if we don't do this, the charts will not be displayed correctly
-        this._refreshCharts();
+        refreshCharts();
       }
     },
   });
+
+  override connectedCallback() {
+    super.connectedCallback();
+    // Refresh the charts when the search result detail is updated
+    this.searchResultDetailSignal.subscribe(() => {
+      refreshCharts();
+    });
+  }
 
   /**
    * Slot nodes
    */
   @queryAssignedNodes({slot: 'col-3', flatten: true})
   slotNodes!: Array<Node>;
-
-  /**
-   * Refresh vega charts by dispatching a resize event
-   * This is needed because vega charts are not displayed correctly because of the hidden sidebar
-   * @private
-   */
-  private _refreshCharts() {
-    setTimeout(() => {
-      window.dispatchEvent(new Event('resize'));
-    }, 0);
-  }
 
   override render() {
     const rowClass = {
@@ -106,7 +104,13 @@ export class SearchLayoutPage extends SearchaliciousResultCtlMixin(
             hidden: this.chartSideBarState.value === SideBarState.CLOSED,
           })}"
         >
-          <slot name="col-3"></slot>
+          <div
+            class="${classMap({
+              hidden: !this.searchResultDetail.isSearchLaunch,
+            })}"
+          >
+            <slot name="col-3"></slot>
+          </div>
         </div>
       </div>
     `;

--- a/frontend/src/utils/charts.ts
+++ b/frontend/src/utils/charts.ts
@@ -1,0 +1,10 @@
+export const refreshCharts = () => {
+  /**
+   * Refresh vega charts by dispatching a resize event
+   * This is needed because vega charts are not displayed correctly because of the hidden sidebar
+   * @private
+   */
+  return setTimeout(() => {
+    window.dispatchEvent(new Event('resize'));
+  }, 0);
+};


### PR DESCRIPTION
### What
-  hide charts when search is not launched

### Screenshot

![image](https://github.com/openfoodfacts/search-a-licious/assets/65901733/522be6c5-3f48-4fa4-a248-003a27bd3bb5)
Before charts show "no data"
### Part of 
- https://github.com/orgs/openfoodfacts/projects/96/views/2?pane=issue&itemId=69854467
