### PR TITLE
build: add es_synonyms to external volumes creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_COMPOSE_TEST=COMPOSE_PROJECT_NAME=search_test docker compose --env-file=$
 
 create_external_volumes:
 	@echo "🔎 Creating external volumes (production only) …"
-	@for vol_name in esdata01 esdata02; \
+	@for vol_name in esdata01 esdata02 es_synonyms; \
 	do \
 		vol_name=${COMPOSE_PROJECT_NAME}_$$vol_name; \
 		echo creating docker volume $$vol_name \


### PR DESCRIPTION
We added a volume but forgot to add it in external volumes creation.