### PR TITLE
fix: handle invalid lucene query term values gracefully

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -112,7 +112,7 @@ def status_for_response(result: SearchResponse):
 @app.post("/search")
 def search(
     response: Response, search_parameters: Annotated[PostSearchParameters, Body()]
-):
+) -> SearchResponse:
     """This is the main search endpoint.
 
     It uses POST request to ensure privacy.

--- a/app/search.py
+++ b/app/search.py
@@ -4,19 +4,19 @@ from typing import cast
 from . import config
 from ._types import (
     DebugInfo,
+    ErrorSearchResponse,
     QueryAnalysis,
     SearchParameters,
     SearchResponse,
     SearchResponseDebug,
-    SuccessSearchResponse,
-    ErrorSearchResponse,
     SearchResponseError,
+    SuccessSearchResponse,
 )
 from .charts import build_charts
+from .exceptions import QueryCheckError
 from .facets import build_facets
 from .postprocessing import BaseResultProcessor, load_result_processor
 from .query import build_elasticsearch_query_builder, build_search_query, execute_query
-from .exceptions import QueryCheckError
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +91,7 @@ def search(
         )
     except QueryCheckError as e:
         return ErrorSearchResponse(
-            debug=None,
+            debug=SearchResponseDebug(),
             errors=[SearchResponseError(title="QueryCheckError", description=str(e))],
         )
     (

--- a/app/search.py
+++ b/app/search.py
@@ -92,7 +92,7 @@ def search(
     except QueryCheckError as e:
         return ErrorSearchResponse(
             debug=None,
-            errors=[SearchResponseError(title="QueryCheckError", description=str(e))]
+            errors=[SearchResponseError(title="QueryCheckError", description=str(e))],
         )
     (
         logger.debug(


### PR DESCRIPTION
### What
- Handle invalid Lucene query term values gracefully to prevent HTTP 500 errors.

### Screenshot
<!-- Insert a screenshot to provide visual record of your changes, if visible -->

### Fixes bug(s)
- #253

### Part of 
- #253
