### PR TITLE
fix(cli): raise non-zero exit on import errors

### DIFF
--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -112,7 +112,7 @@ def import_data(
     logger.info("Import time: %s seconds", end_time - start_time)
     if num_errors:
         logger.error("There were %s errors during import", num_errors)
-        typer.Exit(1)
+        raise typer.Exit(code=1)
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
This PR ensures the import CLI command fails with a non-zero exit status when import errors occur. The command now raises an explicit Typer exit in the error path, making failure detection reliable for CI and scripts.

---

## Related issue
- Fixes: #377

---

## Scope
- `main.py`

---

## What changed
- In the import command flow:
  - When `num_errors > 0`:
    - Log the error count
    - Raise explicit exit:
      ```python
      raise typer.Exit(code=1)
      ```

---

## Why this is correct
- Typer requires raising `Exit` to terminate with a specific status code  
- Ensures CLI behavior aligns with standard Unix conventions  
- Enables reliable failure detection in CI and automation workflows  

---

## Testing Done
- Backend unit tests: passed  
- Backend integration tests: passed (with expected xfailed cases)  
- Frontend test suite: passed  