### PR TITLE
fix(ci): correct USER_UID env var in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
           echo "" > .envrc
           echo CONFIG_PATH=data/config/openfoodfacts.yml >> .envrc
           echo OFF_API_URL=https://world.openfoodfacts.org >> .envrc
-          echo USER_IID=$(id -u) >>.envrc
+          echo USER_UID=$(id -u) >>.envrc
           echo USER_GID=$(id -g) >>.envrc
           make build
       - name: Enforce pre-commit hook server side


### PR DESCRIPTION
## Summary
This PR fixes a typo in the pre-commit workflow where `USER_IID` was exported instead of `USER_UID`.

The correction ensures UID-based behavior remains consistent for Docker build/test steps in CI.

---

## Related issue
- Fixes: #379

---

## What changed
- Updated one line in `pre-commit.yml`:
  - Replaced `USER_IID` with `USER_UID`

---

## Why this is needed
- Build scripts and container ownership logic expect `USER_UID`
- Prevents UID mismatches in CI environments
- Improves consistency for Docker-based workflow steps

---

## Scope
- `pre-commit.yml` (single-line change)

---

## Testing Done
- Backend unit tests: passed  
- Backend integration tests: passed  
- Frontend build: passed  
- Frontend tests: passed in dev and prod modes