### PR TITLE
fix(search): invalidate runtime caches when config changes

### DIFF
--- a/app/search.py
+++ b/app/search.py
@@ -24,9 +24,34 @@ logger = logging.getLogger(__name__)
 # we cache query builder and result processor here for faster processing
 _ES_QUERY_BUILDERS = {}
 _RESULT_PROCESSORS = {}
+_CACHED_CONFIG_ID: int | None = None
+
+
+def invalidate_runtime_caches():
+    """Clear in-process caches used by search runtime."""
+    global _CACHED_CONFIG_ID
+    _ES_QUERY_BUILDERS.clear()
+    _RESULT_PROCESSORS.clear()
+    _CACHED_CONFIG_ID = None
+
+
+def _ensure_runtime_caches_match_config():
+    """Invalidate caches when global config object changed."""
+    global _CACHED_CONFIG_ID
+    current_config_id = id(config.get_config())
+    if _CACHED_CONFIG_ID is None:
+        _CACHED_CONFIG_ID = current_config_id
+        return
+
+    if _CACHED_CONFIG_ID != current_config_id:
+        logger.info("Global config changed, invalidating search runtime caches")
+        _ES_QUERY_BUILDERS.clear()
+        _RESULT_PROCESSORS.clear()
+        _CACHED_CONFIG_ID = current_config_id
 
 
 def get_es_query_builder(index_id):
+    _ensure_runtime_caches_match_config()
     if index_id not in _ES_QUERY_BUILDERS:
         index_config = config.get_config().indices[index_id]
         _ES_QUERY_BUILDERS[index_id] = build_elasticsearch_query_builder(index_config)
@@ -34,6 +59,7 @@ def get_es_query_builder(index_id):
 
 
 def get_result_processor(index_id):
+    _ensure_runtime_caches_match_config()
     if index_id not in _RESULT_PROCESSORS:
         index_config = config.get_config().indices[index_id]
         _RESULT_PROCESSORS[index_id] = load_result_processor(index_config)

--- a/tests/unit/test_search_runtime_cache.py
+++ b/tests/unit/test_search_runtime_cache.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import app.search as search
+
+
+def test_query_builder_cache_invalidation_on_config_change(monkeypatch):
+    config_holder = {
+        "config": SimpleNamespace(indices={"off": "index_config_v1"})
+    }
+    builder_calls: list[str] = []
+
+    monkeypatch.setattr(search.config, "get_config", lambda: config_holder["config"])
+
+    def fake_builder(index_config):
+        builder_calls.append(index_config)
+        return f"builder:{index_config}"
+
+    monkeypatch.setattr(search, "build_elasticsearch_query_builder", fake_builder)
+
+    search.invalidate_runtime_caches()
+
+    first_builder = search.get_es_query_builder("off")
+    second_builder = search.get_es_query_builder("off")
+
+    assert first_builder == "builder:index_config_v1"
+    assert second_builder == first_builder
+    assert builder_calls == ["index_config_v1"]
+
+    config_holder["config"] = SimpleNamespace(indices={"off": "index_config_v2"})
+    third_builder = search.get_es_query_builder("off")
+
+    assert third_builder == "builder:index_config_v2"
+    assert builder_calls == ["index_config_v1", "index_config_v2"]
+
+
+def test_result_processor_cache_invalidation_on_config_change(monkeypatch):
+    config_holder = {
+        "config": SimpleNamespace(indices={"off": "index_config_v1"})
+    }
+    processor_calls: list[str] = []
+
+    monkeypatch.setattr(search.config, "get_config", lambda: config_holder["config"])
+
+    def fake_processor_loader(index_config):
+        processor_calls.append(index_config)
+        return f"processor:{index_config}"
+
+    monkeypatch.setattr(search, "load_result_processor", fake_processor_loader)
+
+    search.invalidate_runtime_caches()
+
+    first_processor = search.get_result_processor("off")
+    second_processor = search.get_result_processor("off")
+
+    assert first_processor == "processor:index_config_v1"
+    assert second_processor == first_processor
+    assert processor_calls == ["index_config_v1"]
+
+    config_holder["config"] = SimpleNamespace(indices={"off": "index_config_v2"})
+    third_processor = search.get_result_processor("off")
+
+    assert third_processor == "processor:index_config_v2"
+    assert processor_calls == ["index_config_v1", "index_config_v2"]


### PR DESCRIPTION
## Summary

This PR adds automatic invalidation for in-process search caches when the global configuration object changes.

It prevents stale query builders and result processors from being reused after configuration reloads, ensuring runtime behavior always matches the active configuration.

---

## Related Issue

Fixes #386

---

## What Changed

- Added automatic cache invalidation when global config changes
- Preserved cache reuse when configuration remains unchanged
- Prevented stale query builders and result processors after reload
- Added unit tests for cache reuse and invalidation behavior

---

## Affected Files

- `search.py`
- `test_search_runtime_cache.py`

---

## Testing

Full local gate executed successfully:

- Backend unit tests ✅
- Backend integration tests ✅
- Frontend build and tests (dev) ✅
- Frontend build and tests (prod) ✅

---

## Notes

This is a runtime consistency improvement with no user-facing API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Search behavior now refreshes automatically when index configuration changes.
  - Added support for manually clearing search runtime caches when needed.

- **Tests**
  - Added coverage confirming cached search components are reused appropriately and refreshed after configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->