### PR TITLE
refactor(frontend): add explicit facet types for search result signal

### DIFF
--- a/frontend/src/interfaces/search-result-interfaces.ts
+++ b/frontend/src/interfaces/search-result-interfaces.ts
@@ -1,0 +1,16 @@
+export interface FacetItem {
+  key: string;
+  name: string;
+}
+
+export interface FacetInfo {
+  name: string;
+  // TODO: add other types if needed
+  items: FacetItem[];
+}
+
+export interface FacetsInfos {
+  [key: string]: FacetInfo;
+}
+
+export type ChartsInfos = Record<string, object>;

--- a/frontend/src/search-facets.ts
+++ b/frontend/src/search-facets.ts
@@ -17,21 +17,11 @@ import {WHITE_PANEL_STYLE} from './styles';
 import {SearchaliciousFacetsInterface} from './interfaces/facets-interfaces';
 import {SearchaliciousResultCtlMixin} from './mixins/search-results-ctl';
 import {SearchCtlGetMixin} from './mixins/search-ctl-getter';
-
-interface FacetsInfos {
-  [key: string]: FacetInfo;
-}
-
-interface FacetInfo {
-  name: string;
-  // TODO: add other types if needed
-  items: FacetItem[];
-}
-
-interface FacetItem {
-  key: string;
-  name: string;
-}
+import {
+  FacetInfo,
+  FacetItem,
+  FacetsInfos,
+} from './interfaces/search-result-interfaces';
 
 interface FacetTerm extends FacetItem {
   count: number;

--- a/frontend/src/signals.ts
+++ b/frontend/src/signals.ts
@@ -1,4 +1,5 @@
 import {Signal, signal} from '@lit-labs/preact-signals';
+import {ChartsInfos, FacetsInfos} from './interfaces/search-result-interfaces';
 
 /**
  * Signals to indicate if the search can be reset.
@@ -22,11 +23,11 @@ const _isSearchChanged: Record<string, Signal> = {} as Record<
  * Search result as returned by a search request, payload of searchResult signal
  */
 export type SearchResultDetail = {
-  charts: Record<string, object>;
+  charts: ChartsInfos;
   count: number;
   currentPage: number;
   displayTime: number;
-  facets: Object; // FIXME: we could be more precise
+  facets: FacetsInfos;
   isCountExact: boolean;
   isSearchLaunch: boolean;
   pageCount: number;


### PR DESCRIPTION
## Summary

This PR introduces shared explicit interfaces for search result facets and charts, replacing weak `Object` typing in `SearchResultDetail`.

It aligns facet-related types across shared signal state and facet component implementations, improving maintainability and type safety without changing runtime behavior.

---

## Related Issue

Fixes #388

---

## What Changed

- Added explicit shared interfaces for search result facets
- Added shared interfaces for chart-related facet data
- Replaced weak `Object` typing in `SearchResultDetail`
- Unified facet-related typing across signal state and components
- Improved static type safety and developer ergonomics

---

## Affected Files

- `signals.ts`
- `search-facets.ts`
- `search-result-interfaces.ts`

---

## Testing

Full local gate executed successfully:

- Backend unit tests ✅
- Backend integration tests ✅
- Frontend build and tests (dev) ✅
- Frontend build and tests (prod) ✅

---

## Notes

This is a frontend refactor focused on stronger typing and maintainability with no functional behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the consistency and clarity of search result data structures.
  * Standardized facet and chart information types across the application.
  * Strengthened type definitions for search result details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->