### PR TITLE
feat: add serving_size and serving_quantity to OFF index schema

### DIFF
--- a/data/config/openfoodfacts.yml
+++ b/data/config/openfoodfacts.yml
@@ -156,6 +156,10 @@ indices:
             type: float
           alcohol_100g:
             type: float
+      serving_size:
+        type: text
+      serving_quantity:
+        type: float
       nutriscore_data:
         type: disabled
       nutriscore_grade:

--- a/tests/int/data/test_off.yml
+++ b/tests/int/data/test_off.yml
@@ -44,6 +44,10 @@ indices:
             type: float
           fat_100g:
             type: float
+      serving_size:
+        type: text
+      serving_quantity:
+        type: float
       completeness:
         type: float
     lang_separator: _

--- a/tests/int/test_search.py
+++ b/tests/int/test_search.py
@@ -28,6 +28,8 @@ def search_sample():
             product_name_fr="Sucre semoule principal",
             categories_tags=["en:sweeteners", "en:sugars", "en:granulated-sugars"],
             labels_tags=["en:no-lactose", "en:organic"],
+            serving_size="1 tsp (4 g)",
+            serving_quantity=4,
         ),
         Product(
             code="3012345670002",
@@ -452,3 +454,20 @@ def test_fields(req_type, sample_data, test_client):
     assert set(
         attributes for result in data["hits"] for attributes in result.keys()
     ) == {"code", "product_name"}
+
+
+@pytest.mark.parametrize("req_type", GET_POST)
+def test_serving_fields(req_type, sample_data, test_client):
+    params = {
+        "sort_by": "code",
+        "langs": ["en"],
+        "fields": ["code", "serving_size", "serving_quantity"],
+    }
+    _, data = do_search(test_client, req_type, params)
+    hits_by_code = {h["code"]: h for h in data["hits"]}
+    main_sugar = hits_by_code.get("3012345670001")
+    assert main_sugar is not None, (
+        f"expected enriched product 3012345670001 in hits; got {list(hits_by_code)}"
+    )
+    assert main_sugar["serving_size"] == "1 tsp (4 g)"
+    assert main_sugar["serving_quantity"] == 4.0

--- a/tests/unit/data/openfoodfacts_config.yml
+++ b/tests/unit/data/openfoodfacts_config.yml
@@ -140,6 +140,10 @@ indices:
             type: float
           fat_100g:
             type: float
+      serving_size:
+        type: text
+      serving_quantity:
+        type: float
       nutriscore_data:
         type: disabled
       nutriscore_grade:

--- a/tests/unit/data/test_mapping.json
+++ b/tests/unit/data/test_mapping.json
@@ -6875,6 +6875,12 @@
     "scans_n": {
       "type": "integer"
     },
+    "serving_quantity": {
+      "type": "float"
+    },
+    "serving_size": {
+      "type": "text"
+    },
     "states": {
       "fields": {
         "aa": {


### PR DESCRIPTION
The OFF product schema carries per-100g nutriments AND per-serving info (`serving_size` as a label string, `serving_quantity` as the parsed gram weight). Per-100g nutriments are already indexed; per-serving siblings are not, so downstream consumers can't surface per-serving info via search-a-licious responses.

This adds both fields to the OFF index config:

- `serving_size`: `type: text` — user-contributed label string (`"2 Tbsp (32 g)"`, `"100g"`, `"1 cup (240 ml)"`)
- `serving_quantity`: `type: float` — parsed grams per serving

## Changes

- `data/config/openfoodfacts.yml` — two field entries adjacent to `nutriments`
- `tests/int/data/test_off.yml` + `tests/unit/data/openfoodfacts_config.yml` — matching entries in both test-schema files
- `tests/int/test_search.py` — adds serving values to one product in `search_sample()` and a new `test_serving_fields` test asserting both fields project through ES into the search response
- `tests/unit/data/test_mapping.json` — regenerated via `pytest tests/unit/test_indexing.py --update-results`

## Local validation

- `make test_api_unit` → 42/42 pass
- `make test_api_integration` → 75 pass, 3 xfailed (vs. 73/3 baseline; +2 is the new test × GET/POST)

## Question for reviewers

`serving_quantity` arrives from the OFF source doc as a string in many products but as a number in others. I picked `type: float` for parity with the per-100g nutriments. If you'd prefer `text` for consistency with `serving_size`, happy to switch.

## Note

This is a schema-only addition. Existing OFF indexes won't have the new fields populated until reindexed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for serving-related fields in product search results, including serving size and serving quantity.
  * Search responses can now return these fields when requested, with values enriched from product data.

* **Tests**
  * Expanded integration and unit coverage to validate the new serving fields and their expected output in search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->