### PR TITLE
fix: correct USER_IID to USER_UID in pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
           echo "" > .envrc
           echo CONFIG_PATH=data/config/openfoodfacts.yml >> .envrc
           echo OFF_API_URL=https://world.openfoodfacts.org >> .envrc
-          echo USER_IID=$(id -u) >>.envrc
+          echo USER_UID=$(id -u) >>.envrc
           echo USER_GID=$(id -g) >>.envrc
           make build
       - name: Enforce pre-commit hook server side


### PR DESCRIPTION
Fixes #379

The pre-commit workflow was setting `USER_IID=$(id -u)` but the 
build scripts expect `USER_UID`. Simple one-character typo fix.